### PR TITLE
add ellipsis to the markdown show on the homepage

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,32 @@
+import ReactMarkdown from "react-markdown";
+
+const Markdown: React.FC<{ content: string }> = ({ content }) => {
+  return (
+    <ReactMarkdown
+      // eslint-disable-next-line react/no-children-prop
+      children={content}
+      linkTarget="_blank"
+      components={{
+        h1: ({ node, ...props }) => (
+          <h2 className="text-xl font-normal" {...props} />
+        ),
+        h2: ({ node, ...props }) => (
+          <h3 className="text-lg font-normal" {...props} />
+        ),
+        h3: ({ node, ...props }) => (
+          <h4 className="text-md font-normal" {...props} />
+        ),
+        h4: ({ node, ...props }) => (
+          <h5 className="text-sm font-normal" {...props} />
+        ),
+        h5: ({ node, ...props }) => (
+          <h6 className="text-sm font-normal" {...props} />
+        ),
+        h6: "p",
+      }}
+      className="min-w-full prose rounded-md"
+    />
+  );
+};
+
+export default Markdown;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,9 @@
 import type { NextPage } from "next";
-import { trpc } from "../utils/trpc";
-import Navbar from "../components/Navbar";
 import Link from "next/link";
+import { trpc } from "../utils/trpc";
+
+import Navbar from "../components/Navbar";
+import Markdown from "../components/Markdown";
 
 const Home: NextPage = () => {
   const postQuery = trpc.useQuery(["post.all"], {
@@ -35,7 +37,10 @@ const Home: NextPage = () => {
             </span>
             {/* <Image width={256} height={256} /> */}
             {/* <div className="h-96 w-full bg-gray-300 rounded-md"></div> */}
-            <div className="truncate">{post.content}</div>
+            {/* <div className="truncate">{post.content}</div> */}
+            <div className="two-line-ellipsis">
+              <Markdown content={post.content ? post.content : ""} />
+            </div>
             <div className="flex justify-between mt-3">
               <div className="flex justify-center items-center gap-2">
                 <button>Upvote</button>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.two-line-ellipsis {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Purpose
- The markdown shows on the index page should now be limited to 2 lines of text. This will prevent any issue with having a post with 100s of lines of text from taking up too much room.