### PR TITLE
update prisma content colum type

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,8 +17,8 @@ datasource db {
 model Post {
   id        Int      @id @default(autoincrement())
   title     String
-  content   String?  @db.VarChar(1000)
+  content   String?  @db.Text()
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now())
-  slug      String
+  slug      String?  @unique
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,7 @@
 
 .two-line-ellipsis {
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 10;
   -webkit-box-orient: vertical;
   overflow: hidden;
 }


### PR DESCRIPTION
## Purpose
- Change the data type of content field on Post table to Text. Previously VarChar(1000) only allowed posts with a body content length less than or equal to that. 
- Read more about it: (scroll down 😊) [Text](https://dev.mysql.com/doc/refman/8.0/en/storage-requirements.html)